### PR TITLE
Diary and Product Backlog update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Progress is tracked with a [diary](./productionLog/diary.md) file and with the P
 | Main page          | ✅ | 1      | Basic buttons, thumbnail grid, header                                   |
 | Sample data base   | 🔨 | 1      | Pick videos, manually create preview/thumbnail                          |
 | Logic to videos    | 🔨 | 1      | Clicking on thumbnail opens video Modal; buttons... basic for now!      |
-| Navigation         | 🔨 | 1       | Videos/page... 20? 50?... loading new set?                              |
+| Navigation         | ✅ | 1       | Videos/page... 20? 50?... loading new set?                              |
 | Basic search       | Not started |        | Searchbar, logic of filter                                              |
 | Info database      | Not started |        | Tags/Names/Likes(?)/Comments... data that cannot be obtained from video |
 | Info input         | Not started |        | Input boxes when editing data related to a video                        |

--- a/productionLog/diary.md
+++ b/productionLog/diary.md
@@ -164,3 +164,9 @@ At the end of the day, "Main Page" task from the Product Backlog was marked as d
 <img src="./progress4.png" width="800px">
 
 - Added logic to navigation - which videos are shown
+
+"Navigation" task from the Product Backlog was marked as done ✅.
+
+- Started compiling actual sample data base (few videos)
+
+    - Create thumbnails, preview videos etc.


### PR DESCRIPTION
Update the product backlog table on main Readme.md, and add notice about the next task to diary.